### PR TITLE
Don't allow newserver connections when PAUSE <db> was issued.

### DIFF
--- a/src/objects.c
+++ b/src/objects.c
@@ -576,7 +576,7 @@ bool find_server(PgSocket *client)
 		return true;
 
 	/* try to get idle server, if allowed */
-	if (cf_pause_mode == P_PAUSE) {
+	if (cf_pause_mode == P_PAUSE || pool->db->db_paused) {
 		server = NULL;
 	} else {
 		while (1) {


### PR DESCRIPTION
Hi,
My coleague, Gianni Ciolli, hit a bug with "PAUSE db" where pgbouncer allows new client connection to actually connect to the paused server. It works fine with plain "PAUSE", just "PAUSE db" is affected.

This is because "PAUSE db" does not set cf_pause_mode but only db->db_paused, which by itself is correct behaviour but then the find_server function completely ignores the db->db_paused setting.

So here is one liner to fix that.